### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,6 +3,9 @@ name: markdownlint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: Markdown Lint


### PR DESCRIPTION
Potential fix for [https://github.com/chorrell/cwh_hobo/security/code-scanning/1](https://github.com/chorrell/cwh_hobo/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since this workflow only checks out code and runs a linter, it only needs read access to repository contents; no write or additional scopes are required.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow root, so it applies to all jobs in this workflow. Concretely, in `.github/workflows/markdownlint.yml`, add:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (for example, after line 5). No imports, methods, or additional definitions are needed; this is purely a YAML configuration change inside the existing workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
